### PR TITLE
Travis ci with sample test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: python
+
+python:
+  - "3.6"
+  - "3.7"
+  - "3.8"
+
+os:
+  - linux
+
+install:
+  - pip install --editable .
+
+services:
+  - docker
+
+script:
+  - python3 ./tests/test1.py

--- a/tests/test1.py
+++ b/tests/test1.py
@@ -1,0 +1,34 @@
+import subprocess
+import os
+import time
+import sys
+
+Timeout = 540
+
+def linux_test():
+	local_start_out = subprocess.Popen(["intermine_boot", "start", "local"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+	print("started local intermine")
+	start = time.time()
+	
+	while True:
+		time.sleep(1)
+		end = time.time()
+		curl_out = subprocess.run(["curl", "http://localhost:9999/biotestmine/service/version"], shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+		if(curl_out.stdout!=''):
+			break
+		if((end-start)>Timeout):
+			local_start_out.kill()
+			subprocess.run(["intermine_boot","stop","local"])
+			print("process ran for too long")
+			sys.exit(1)
+	
+	subprocess.run(["intermine_boot","stop","local"])
+	print("This test was successful")
+
+os_name = sys.platform
+print("You are using the following operating system:", os_name)
+
+if(os_name=="linux2" or "linux"):
+	linux_test()
+else:
+	print("This is not a supported operating system in this test script")

--- a/tests/test1.py
+++ b/tests/test1.py
@@ -14,8 +14,10 @@ def linux_test():
 		time.sleep(1)
 		end = time.time()
 		curl_out = subprocess.run(["curl", "http://localhost:9999/biotestmine/service/version"], shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+		
 		if(curl_out.stdout!=''):
 			break
+		
 		if((end-start)>Timeout):
 			local_start_out.kill()
 			subprocess.run(["intermine_boot","stop","local"])


### PR DESCRIPTION
Issue #4  needed a test to be triggered from the travis CI. I have made a PR adding this in #3 . 
My approach for the test is as follows:
I have written os-specific test functions for the following os:
1. Linux
2. Windows
3. OSX
The aproach is, first the subprocess intermine_boot start local is started. Then, `curl http://localhost:9999/biotestmine/service/version` is run at an interval of 1 sec until a response is received. This runs for 9 mins(in travis if no output is received by the script for more than 10 minutes, it times out automatically). The test fails for windows because python is currently unsupported on the Windows Build Environment in travis and though for osx it does try to fetch some python repos (which fails) only go is supported in osx. 
I have written a .travis.yml file to trigger this test for #4   which is as follows.
I test for python environments python 3.5+, ie 3.6, 3.7, 3.8 which first will trigger the test1.py in different os(linux, osx, windows). It first runs `pip install --editable . `which installs the utility. Then I run `./test/test.py` this runs the intermine_boot utility to check wether it runs properly as stated above. This just an initial pull request and will try to add the osx support for unsupported languages like python later.
I would also like to thank @uosl, @leoank  for their insights and clarifications.