### PR TITLE
Fix #26: add docker-intermine-gradle as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "docker-intermine-gradle"]
+	path = docker-intermine-gradle
+	url = https://github.com/intermine/docker-intermine-gradle

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,11 @@
-recursive-include docker-intermine-gradle *
+include docker-intermine-gradle/ *.yml
+
+include docker-intermine-gradle/intermine-builder/ *.sh *.Dockerfile
+
+include docker-intermine-gradle/postgres/ *.conf *.sh *.Dockerfile docker-healthcheck
+
+include docker-intermine-gradle/solr/ *.Dockerfile
+include docker-intermine-gradle/solr/scripts/ *.sh
+
+include docker-intermine-gradle/tomcat/ *.Dockerfile
+include docker-intermine-gradle/configs/ *.xml

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include docker-intermine-gradle *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,11 +1,6 @@
-include docker-intermine-gradle/ *.yml
+include docker-intermine-gradle/*.yml
 
-include docker-intermine-gradle/intermine-builder/ *.sh *.Dockerfile
-
-include docker-intermine-gradle/postgres/ *.conf *.sh *.Dockerfile docker-healthcheck
-
-include docker-intermine-gradle/solr/ *.Dockerfile
-include docker-intermine-gradle/solr/scripts/ *.sh
-
-include docker-intermine-gradle/tomcat/ *.Dockerfile
-include docker-intermine-gradle/configs/ *.xml
+recursive-include docker-intermine-gradle/intermine_builder *
+recursive-include docker-intermine-gradle/postgres *
+recursive-include docker-intermine-gradle/solr *
+recursive-include docker-intermine-gradle/tomcat *

--- a/intermine_boot/docker.py
+++ b/intermine_boot/docker.py
@@ -45,7 +45,7 @@ def _get_compose_path(options, env):
     if options['build_images']:
         compose_file = 'local.docker-compose.yml'
     return compose_path / compose_file
-        
+
 
 def _create_volume_dirs(compose_path, data_dir):
     with open(compose_path, 'r') as stream:

--- a/intermine_boot/docker.py
+++ b/intermine_boot/docker.py
@@ -40,7 +40,7 @@ def _store_conf(path_to_config, options):
 
 
 def _get_compose_path(options, env):
-    compose_path = Path(os.getcwd()) / './docker-intermine-gradle'
+    compose_path = Path(__file__).parent.parent / 'docker-intermine-gradle'
     compose_file = 'dockerhub.docker-compose.yml'
     if options['build_images']:
         compose_file = 'local.docker-compose.yml'


### PR DESCRIPTION
This is fix for #26 

To check, get the branch and run "git submodule update --init" and run other intermine_boot commands as usual.

Note:
- Right now the data for containers is built in the docker-intermine-gradle. This is because the format of volumes in compose files is ./data builds data folder in compose file path. But, it would be resolved as we are shifting to docker-py.
